### PR TITLE
Update Svelte configuration and dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,5 +42,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: skywarth/vite-github-pages-deployer@v1.5.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          build_path: ./build
+          public_base_path: /portfolio
+          package_manager: pnpm

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@storybook/addon-vitest": "^9.1.3",
     "@storybook/sveltekit": "^9.1.3",
     "@sveltejs/adapter-auto": "^3.0.0",
+    "@sveltejs/adapter-static": "^3.0.9",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
         version: 3.3.1(@sveltejs/kit@2.37.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))
+      '@sveltejs/adapter-static':
+        specifier: ^3.0.9
+        version: 3.0.9(@sveltejs/kit@2.37.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))
       '@sveltejs/kit':
         specifier: ^2.0.0
         version: 2.37.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11))
@@ -1201,6 +1204,11 @@ packages:
 
   '@sveltejs/adapter-auto@3.3.1':
     resolution: {integrity: sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/adapter-static@3.0.9':
+    resolution: {integrity: sha512-aytHXcMi7lb9ljsWUzXYQ0p5X1z9oWud2olu/EpmH7aCu4m84h7QLvb5Wp+CFirKcwoNnYvYWhyP/L8Vh1ztdw==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
@@ -3891,6 +3899,10 @@ snapshots:
     dependencies:
       '@sveltejs/kit': 2.37.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11))
       import-meta-resolve: 4.2.0
+
+  '@sveltejs/adapter-static@3.0.9(@sveltejs/kit@2.37.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))':
+    dependencies:
+      '@sveltejs/kit': 2.37.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11))
 
   '@sveltejs/kit@2.37.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11)))(svelte@4.2.20)(vite@5.4.19(@types/node@20.19.11))':
     dependencies:

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,5 @@
 import { mdsvex } from 'mdsvex';
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -7,15 +7,18 @@ const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
 	// for more information about preprocessors
 	preprocess: [vitePreprocess(), mdsvex()],
-	kit: { adapter: adapter({
-		pages: 'build',
-		assets: 'build',
-		fallback: null
-	  }),
-	  paths: {
-		base: process.env.GITHUB_PAGES ? '/portfolio' : '',
-	  }
-	 },
+	kit: { 
+		adapter: adapter({
+			pages: 'build',
+			assets: 'build',
+			fallback: 'index.html',
+			precompress: false,
+			strict: false
+		}),
+		paths: {
+			base: process.env.GITHUB_PAGES ? '/portfolio' : '',
+		}
+	},
 	extensions: ['.svelte', '.svx']
 };
 


### PR DESCRIPTION
- Switched Svelte adapter from '@sveltejs/adapter-auto' to '@sveltejs/adapter-static' for improved static site generation
- Added '@sveltejs/adapter-static' dependency in package.json and pnpm-lock.yaml
- Updated GitHub Actions workflow to include new build path and public base path for deployment